### PR TITLE
Add compatibility for shopware 6.4 and above

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,14 @@
             "role": "Manufacturer"
         }
     ],
-    "version": "1.0.0",
+    "version": "1.0.1",
     "autoload": {
         "psr-4": {
             "ElgentosSeoCanonicalUrl\\": "src/"
         }
+    },
+    "require": {
+        "shopware/core": "^6.4"
     },
     "extra": {
         "shopware-plugin-class": "ElgentosSeoCanonicalUrl\\ElgentosSeoCanonicalUrl",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
             "role": "Manufacturer"
         }
     ],
-    "version": "1.0.1",
+    "version": "2.0.0",
     "autoload": {
         "psr-4": {
             "ElgentosSeoCanonicalUrl\\": "src/"

--- a/src/Resources/views/storefront/page/product-detail/meta.html.twig
+++ b/src/Resources/views/storefront/page/product-detail/meta.html.twig
@@ -1,7 +1,7 @@
 {% sw_extends '@Storefront/storefront/page/product-detail/meta.html.twig' %}
 
 {% block layout_head_canonical %}
-    {% if page.product.parentId and shopware.config.ElgentosSeoCanonicalUrl.config.active %}
+    {% if page.product.parentId and config('ElgentosSeoCanonicalUrl.config.active') %}
         <link rel="canonical" href="{{ seoUrl('frontend.detail.page', { productId: page.product.parentId }) }}" />
     {% else %}
         <link rel="canonical" href="{{ seoUrl('frontend.detail.page', { productId: page.product.id }) }}" />


### PR DESCRIPTION
I'm open for discussions about ensuring backwards compatibility. 
This pull request would break compatibility to Shopware < 6.4.
On the other side, without that PR one couldn't use it in Shopware 6.4 and above.